### PR TITLE
KIT EKP Config - add default GridUI

### DIFF
--- a/config/physik.uni-karlsruhe.de.conf
+++ b/config/physik.uni-karlsruhe.de.conf
@@ -1,7 +1,13 @@
 [global]
 backend = condor
 
+[constants]
+; SLC6 currently uses this grid UI
+gc_glite_location = /cvmfs/grid.cern.ch/emi3ui-latest/etc/profile.d/setup-ui-example.sh
+
+
 [condor]
+; Map GridControl values to corresponding EKP Condor values
 poolArgs req =
   walltimeMin => +RequestWalltime
- ; dataFiles => +Input_Files
+; dataFiles => +Input_Files


### PR DESCRIPTION
All our SLC6 machines currently use the same grid UI
Source it by default.