### PR TITLE
added 'dataset_proc' argument to several providers

### DIFF
--- a/packages/grid_control_cms/provider_cms.py
+++ b/packages/grid_control_cms/provider_cms.py
@@ -30,13 +30,13 @@ CMSLocationFormat = make_enum(['hostname', 'siteDB', 'both'])  # pylint:disable=
 
 class CMSBaseProvider(DataProvider):
 	# required format: <dataset path>[@<instance>][#<block>]
-	def __init__(self, config, datasource_name, dataset_expr, dataset_nick=None):
+	def __init__(self, config, datasource_name, dataset_expr, dataset_nick=None, dataset_proc=None):
 		dataset_config = config.change_view(default_on_change=TriggerResync(['datasets', 'parameters']))
 		self._lumi_filter = dataset_config.get_lookup(['lumi filter', '%s lumi filter' % datasource_name],
 			default={}, parser=parse_lumi_filter, strfun=str_lumi)
 		if not self._lumi_filter.empty():
 			config.set('%s processor' % datasource_name, 'LumiDataProcessor', '+=')
-		DataProvider.__init__(self, config, datasource_name, dataset_expr, dataset_nick)
+		DataProvider.__init__(self, config, datasource_name, dataset_expr, dataset_nick, dataset_proc)
 		# LumiDataProcessor instantiated in DataProcessor.__ini__ will set lumi metadata as well
 		self._lumi_query = dataset_config.get_bool(
 			['lumi metadata', '%s lumi metadata' % datasource_name], default=not self._lumi_filter.empty())

--- a/packages/grid_control_cms/provider_das.py
+++ b/packages/grid_control_cms/provider_das.py
@@ -29,8 +29,8 @@ class DASProvider(CMSBaseProvider):
 	# required format: <dataset path>[@<instance>][#<block>]
 	alias_list = ['das']
 
-	def __init__(self, config, datasource_name, dataset_expr, dataset_nick=None):
-		CMSBaseProvider.__init__(self, config, datasource_name, dataset_expr, dataset_nick)
+	def __init__(self, config, datasource_name, dataset_expr, dataset_nick=None, dataset_proc=None):
+		CMSBaseProvider.__init__(self, config, datasource_name, dataset_expr, dataset_nick, dataset_proc)
 		self._url = config.get('das instance', 'https://cmsweb.cern.ch/das/cache',
 			on_change=TriggerResync(['datasets', 'parameters']))
 		if self._dataset_instance.startswith('http'):

--- a/packages/grid_control_cms/provider_dbsv3.py
+++ b/packages/grid_control_cms/provider_dbsv3.py
@@ -23,8 +23,8 @@ class DBS3Provider(CMSBaseProvider):
 	# required format: <dataset path>[@<instance>][#<block>]
 	alias_list = ['dbs3', 'dbs']
 
-	def __init__(self, config, datasource_name, dataset_expr, dataset_nick=None):
-		CMSBaseProvider.__init__(self, config, datasource_name, dataset_expr, dataset_nick)
+	def __init__(self, config, datasource_name, dataset_expr, dataset_nick=None, dataset_proc=None):
+		CMSBaseProvider.__init__(self, config, datasource_name, dataset_expr, dataset_nick, dataset_proc)
 		if self._dataset_instance.startswith('http'):
 			self._url = self._dataset_instance
 		else:


### PR DESCRIPTION
Fixes error when adding multiple datasets:

```PluginError: Error while creating instance: 'grid_control_cms.provider_dbsv3.DBS3Provider' - TypeError: __init__() got an unexpected keyword argument 'dataset_proc'```