### PR TITLE
EKP Network-migration changed domain names

### DIFF
--- a/config/ekp.kit.edu.conf
+++ b/config/ekp.kit.edu.conf
@@ -1,0 +1,8 @@
+[global]
+backend = condor
+
+[condor]
+; Map GridControl values to corresponding EKP Condor values
+poolArgs req =
+  walltimeMin => +RequestWalltime
+  dataFiles => +Input_Files

--- a/config/physik.uni-karlsruhe.de.conf
+++ b/config/physik.uni-karlsruhe.de.conf
@@ -1,7 +1,1 @@
-[global]
-backend = condor
-
-[condor]
-poolArgs req =
-  walltimeMin => +RequestWalltime
- ; dataFiles => +Input_Files
+ekp.kit.edu.conf


### PR DESCRIPTION
-> new default config file
- keep old file as fallback for a few versions, until everything is migrated