### PR TITLE
VCS parameter parsers

### DIFF
--- a/packages/grid_control/.PLUGINS
+++ b/packages/grid_control/.PLUGINS
@@ -478,6 +478,8 @@
 
     * grid_control.parameters.config_param FormatParameterParser format
 
+    * grid_control.parameters.config_param GitParameterParser git
+
     * grid_control.parameters.config_param LinesParameterParser lines
 
     * grid_control.parameters.config_param ShellParameterParser shell default

--- a/packages/grid_control/.PLUGINS
+++ b/packages/grid_control/.PLUGINS
@@ -486,6 +486,8 @@
 
     * grid_control.parameters.config_param SplitParameterParser split
 
+    * grid_control.parameters.config_param SvnParameterParser svn
+
     * grid_control.parameters.config_param VerbatimParameterParser verbatim
 
    * grid_control.parameters.psource_base ParameterSource

--- a/packages/grid_control/parameters/config_param.py
+++ b/packages/grid_control/parameters/config_param.py
@@ -287,3 +287,16 @@ class GitParameterParser(ParameterParser):
 		os.chdir(old_wd)
 		return [version]
 
+
+class SvnParameterParser(ParameterParser):
+	alias_list = ['svn']
+
+	def parse_value(self, pconfig, varexpr, vn, value):
+		path = clean_path(value)
+		version = "undefined"
+		svn_proc = LocalProcess('svnversion', path)
+		if svn_proc.status(10) == 0: version = svn_proc.get_output(10)[:-1]
+		# different SVN versions yield different output for unversioned directories:
+		if "exported" in version or "Unversioned" in version: version = "undefined"
+		return [version]
+


### PR DESCRIPTION
`git` and `svn` type parameters can be specified: the version (git hash, svn revision) of a specified path is determined:
```
[parameters]
parameters  = svn_ver git_ver
svn_ver = ~/my_svn_dir/
svn_ver type = svn
git_ver = ~/my_git_dir/
git_ver type = git
```