### PR TITLE
setting GC_JOB_ID as the very first thing:

### DIFF
--- a/packages/grid_control/share/gc-run.sh
+++ b/packages/grid_control/share/gc-run.sh
@@ -15,13 +15,13 @@
 
 # grid-control: https://ekptrac.physik.uni-karlsruhe.de/trac/grid-control
 
+export GC_JOB_ID="$1"
+export MY_JOBID="$GC_JOB_ID" # legacy script support
 export GC_DOCLEANUP="true"
 source gc-run.lib || exit 101
 
 set +f
 gc_trap
-export GC_JOB_ID="$1"
-export MY_JOBID="$GC_JOB_ID" # legacy script support
 export GC_LANDINGZONE="$(pwd)"
 export GC_MARKER="$GC_LANDINGZONE/RUNNING.$$"
 export GC_FAIL_MARKER="$GC_LANDINGZONE/GCFAIL"


### PR DESCRIPTION
otherwise grid-control crashes on failure of 'source gc-run.lib' due to
empty job id field in job.info