### PR TITLE
Fixed a bug with a newer condor version

### DIFF
--- a/packages/grid_control/backends/condor_wms/condor_wms.py
+++ b/packages/grid_control/backends/condor_wms/condor_wms.py
@@ -381,6 +381,7 @@ class Condor(BasicWMS):
 		jdlData = [
 			'Universe   = ' + self.settings["jdl"]["Universe"],
 			'Executable = ' + gcExec,
+			'transfer_executable = false',
 			'notify_user = ' + self.settings["jdl"]["NotifyEmail"],
 			'Log = ' + os.path.join(self.getWorkdirPath(), "GC_Condor.%s.log") % self.taskID,
 			'should_transfer_files = YES',


### PR DESCRIPTION
Before running, it tries to copy the executable, which is in the condor/docker case set to "gc-run.sh". The executable itself is transfered by grid-control, but as condor wants to copy it also and can not find it (because it is only valid in the sandbox), it fails.