### PR TITLE
Use the python compatible md5_hex function

### DIFF
--- a/packages/grid_control/backends/condor_wms/condor_wms.py
+++ b/packages/grid_control/backends/condor_wms/condor_wms.py
@@ -25,7 +25,7 @@ from grid_control.backends.wms_local import LocalPurgeJobs, SandboxHelper
 from grid_control.utils import Result, ensure_dir_exists, get_path_share, remove_files, resolve_install_path, safe_write, split_blackwhite_list  # pylint:disable=line-too-long
 from grid_control.utils.activity import Activity
 from grid_control.utils.data_structures import make_enum
-from python_compat import imap, irange, lmap, lzip, md5
+from python_compat import imap, irange, lmap, lzip, md5_hex
 
 
 # if the ssh stuff proves too hack'y: http://www.lag.net/paramiko/
@@ -68,7 +68,7 @@ class Condor(BasicWMS):
 		BasicWMS.__init__(self, config, name,
 			check_executor=CheckJobsMissingState(config, CondorCheckJobs(config)),
 			cancel_executor=cancel_executor)
-		self._task_id = config.get('task id', md5(str(time.time())).hexdigest(), persistent=True)  # FIXME
+		self._task_id = config.get('task id', md5_hex(str(time.time())), persistent=True)  # FIXME
 		# finalize config state by reading values or setting to defaults
 		# load keys for condor pool ClassAds
 		self._jdl_writer = CondorJDLWriter(config)


### PR DESCRIPTION
This is a followup on #39 , but this time using the correct base branch (sorry, I was not sure where to put this PR) and the already provided `python_compat` module. 

This change should not have any effect in case of python2, and makes the module runnable with python3.
The created hashs seems to be the same, but anyway: as this is a random hash, this should not matter.

There are more usages of the raw md5 function in 
* packages/grid_control/backends/htcondor_wms/htcondor_schedd.py
* packages/grid_control/backends/wms_cream.py
* packages/grid_control/backends/wms_grid.py

I can also change those if wanted.