### PR TITLE
Removed the logic to transfer the gc-run ...

### DIFF
--- a/packages/grid_control/backends/condor_wms/condor_wms.py
+++ b/packages/grid_control/backends/condor_wms/condor_wms.py
@@ -22,7 +22,7 @@ from grid_control.backends.condor_wms.processhandler import ProcessHandler
 from grid_control.backends.wms import BackendError, BasicWMS, WMS
 from grid_control.backends.wms_condor import CondorCancelJobs, CondorCheckJobs
 from grid_control.backends.wms_local import LocalPurgeJobs, SandboxHelper
-from grid_control.utils import Result, ensure_dir_exists, get_path_share, remove_files, resolve_install_path, safe_write, split_blackwhite_list  # pylint:disable=line-too-long
+from grid_control.utils import Result, ensure_dir_exists, remove_files, resolve_install_path, safe_write, split_blackwhite_list  # pylint:disable=line-too-long
 from grid_control.utils.activity import Activity
 from grid_control.utils.data_structures import make_enum
 from python_compat import imap, irange, lmap, lzip, md5_hex

--- a/packages/grid_control/backends/condor_wms/condor_wms.py
+++ b/packages/grid_control/backends/condor_wms/condor_wms.py
@@ -322,8 +322,7 @@ class Condor(BasicWMS):
 		return ensure_dir_exists(sandpath, 'sandbox directory', BackendError)
 
 	def _get_script_and_fn_list(self, task):
-		# resolve file paths for different pool types
-		# handle gc executable separately
+		# Get list of files marked for transfer and identify the script command file
 		script_cmd = './gc-run.sh'
 		sb_in_fn_list = [d_s_t[1] for d_s_t in self._get_in_transfer_info_list(task)]
 

--- a/packages/grid_control/backends/condor_wms/condor_wms.py
+++ b/packages/grid_control/backends/condor_wms/condor_wms.py
@@ -324,23 +324,10 @@ class Condor(BasicWMS):
 	def _get_script_and_fn_list(self, task):
 		# resolve file paths for different pool types
 		# handle gc executable separately
-		(script_cmd, sb_in_fn_list) = ('', [])
-		if self._remote_type in (PoolType.SSH, PoolType.GSISSH):
-			for target in imap(lambda d_s_t: d_s_t[2], self._get_in_transfer_info_list(task)):
-				if 'gc-run.sh' in target:
-					script_cmd = os.path.join(self._get_remote_output_dn(), target)
-				else:
-					sb_in_fn_list.append(os.path.join(self._get_remote_output_dn(), target))
-		else:
-			for source in imap(lambda d_s_t: d_s_t[1], self._get_in_transfer_info_list(task)):
-				if 'gc-run.sh' in source:
-					script_cmd = source
-				else:
-					sb_in_fn_list.append(source)
-		if self._universe.lower() == 'docker':
-			script_cmd = './gc-run.sh'
-			sb_in_fn_list.append(get_path_share('gc-run.sh'))
-		return (script_cmd, sb_in_fn_list)
+		script_cmd = './gc-run.sh'
+		sb_in_fn_list = [d_s_t[1] for d_s_t in self._get_in_transfer_info_list(task)]
+
+		return script_cmd, sb_in_fn_list
 
 	def _init_pool_interface(self, config):
 		# prepare commands and interfaces according to selected submit type


### PR DESCRIPTION
... to the local resources and always transfer it

This change enables support for remote resources, since the gc-run.sh file will always be transferred to the worker node. Currently, these resources are only supported, if they use a docker universe. The small overhead for local resources is negligible, since the size of the file is few kB. Differentiation between local and non-local resources is very difficult, especially if the job universe and file paths are considered. Hence, we removed the corresponding parts of the code for a more general and simplified setup.