### PR TITLE
RemoveTaskOutputProcessor

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -207,6 +207,7 @@ SimpleJobManager options
     Specify plugin that processes the output sandbox of successful jobs
 
     List of available plugins:
+     * RemoveTaskOutputProcessor_ (alias: null)
      * SandboxProcessor_ (alias: null)
 
 * ``queue timeout`` = <duration hh[:mm[:ss]]> (Default: disabled (-1))

--- a/packages/grid_control/.PLUGINS
+++ b/packages/grid_control/.PLUGINS
@@ -662,5 +662,7 @@
 
    * grid_control.output_processor TaskOutputProcessor
 
+    * grid_control.output_processor RemoveTaskOutputProcessor null
+
     * grid_control.output_processor SandboxProcessor null
 

--- a/packages/grid_control/job_manager.py
+++ b/packages/grid_control/job_manager.py
@@ -1,4 +1,4 @@
-# | Copyright 2007-2017 Karlsruhe Institute of Technology
+# | Copyright 2007-2018 Karlsruhe Institute of Technology
 # |
 # | Licensed under the Apache License, Version 2.0 (the "License");
 # | you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ class JobManager(NamedPlugin):  # pylint:disable=too-many-instance-attributes
 			cls=JobDB, pargs=(self._get_max_jobs(task), selected), on_change=None)
 		self._disabled_jobs_logfile = config.get_work_path('disabled')
 		self._output_processor = config.get_plugin('output processor', 'SandboxProcessor',
-			cls=TaskOutputProcessor)
+			cls=TaskOutputProcessor, on_change=None)
 
 		self._uii = UserInputInterface()
 		self._interactive_cancel = config.is_interactive(['delete jobs', 'cancel jobs'], True)

--- a/packages/grid_control/output_processor.py
+++ b/packages/grid_control/output_processor.py
@@ -1,4 +1,4 @@
-# | Copyright 2014-2017 Karlsruhe Institute of Technology
+# | Copyright 2014-2018 Karlsruhe Institute of Technology
 # |
 # | Licensed under the Apache License, Version 2.0 (the "License");
 # | you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 # | See the License for the specific language governing permissions and
 # | limitations under the License.
 
-import os, sys, gzip, logging
+import os, sys, gzip, errno, logging
 from grid_control.utils import DictFormat
 from grid_control.utils.data_structures import make_enum
 from grid_control.utils.file_tools import SafeFile
@@ -73,6 +73,19 @@ class SandboxProcessor(TaskOutputProcessor):
 	alias_list = ['null']
 
 	def process(self, dn, task):
+		return True
+
+
+class RemoveTaskOutputProcessor(TaskOutputProcessor):
+	alias_list = ['null']
+
+	def process(self, dn, task):
+		for fname in ('gc.stdout', 'gc.stderr'):
+			try:
+				os.remove(os.path.join(dn, fname))
+			except OSError as e:
+				if e.errno != errno.ENOENT:  # no such file
+					raise
 		return True
 
 


### PR DESCRIPTION
to delete stdout and stderr in output directory

may save a lot of diskspace