### PR TITLE
condor: setting batch name to task name

### DIFF
--- a/packages/grid_control/backends/condor_wms/condor_wms.py
+++ b/packages/grid_control/backends/condor_wms/condor_wms.py
@@ -433,7 +433,8 @@ class Condor(BasicWMS):
 		try:
 			# submit all jobs simultaneously and temporarily store verbose (ClassAdd) output
 			activity = Activity('queuing jobs at scheduler')
-			proc = self._proc_factory.logged_execute(self._submit_exec, ' -verbose ' + submit_jdl_fn)
+			submit_args = ' -verbose -batch-name ' + task.get_description().task_name + ' ' + submit_jdl_fn
+			proc = self._proc_factory.logged_execute(self._submit_exec, submit_args)
 
 			# extract the Condor ID (WMS ID) of the jobs from output ClassAds
 			jobnum_gc_id_list = []

--- a/packages/grid_control/backends/wms_condor.py
+++ b/packages/grid_control/backends/wms_condor.py
@@ -1,4 +1,4 @@
-# | Copyright 2016-2017 Karlsruhe Institute of Technology
+# | Copyright 2016-2018 Karlsruhe Institute of Technology
 # |
 # | Licensed under the Apache License, Version 2.0 (the "License");
 # | you may not use this file except in compliance with the License.

--- a/packages/grid_control/utils/webservice_urllib2.py
+++ b/packages/grid_control/utils/webservice_urllib2.py
@@ -1,4 +1,4 @@
-# | Copyright 2016-2017 Karlsruhe Institute of Technology
+# | Copyright 2016-2018 Karlsruhe Institute of Technology
 # |
 # | Licensed under the Apache License, Version 2.0 (the "License");
 # | you may not use this file except in compliance with the License.

--- a/packages/grid_control_api.py
+++ b/packages/grid_control_api.py
@@ -1,4 +1,4 @@
-# | Copyright 2007-2017 Karlsruhe Institute of Technology
+# | Copyright 2007-2018 Karlsruhe Institute of Technology
 # |
 # | Licensed under the Apache License, Version 2.0 (the "License");
 # | you may not use this file except in compliance with the License.


### PR DESCRIPTION
For more useful batch grouping in condor outputs (e.g. condor_q does not show everything as "CMD: gc-run.sh")