### PR TITLE
Avoid T1_DE_KIT to be blacklisted from user jobs

### DIFF
--- a/config/desy.de.conf
+++ b/config/desy.de.conf
@@ -19,3 +19,6 @@ software requirement map =
 [condor]
 poolArgs req =
 	walltimeMin => +RequestWalltime
+
+[dataset]
+phedex sites += T1_DE_KIT

--- a/config/ekp.kit.edu.conf
+++ b/config/ekp.kit.edu.conf
@@ -6,3 +6,6 @@ backend = condor
 poolArgs req =
 	walltimeMin => +RequestWalltime
 	dataFiles => +Input_Files
+
+[dataset]
+phedex sites += T1_DE_KIT

--- a/packages/grid_control_cms/provider_cms.py
+++ b/packages/grid_control_cms/provider_cms.py
@@ -43,7 +43,7 @@ class CMSBaseProvider(DataProvider):
 			['lumi metadata', '%s lumi metadata' % datasource_name], default=not self._lumi_filter.empty())
 		config.set('phedex sites matcher mode', 'ShellStyleMatcher', '?=')
 		# PhEDex blacklist: 'T1_*_Disk nodes allow user jobs - other T1's dont!
-		self._phedex_filter = dataset_config.get_filter('phedex sites', '-* T1_DE_KIT T1_*_Disk T2_* T3_*',
+		self._phedex_filter = dataset_config.get_filter('phedex sites', '-* T1_*_Disk T2_* T3_*',
 			default_matcher='BlackWhiteMatcher', default_filter='StrictListFilter')
 		self._only_complete = dataset_config.get_bool('only complete sites', True)
 		self._only_valid = dataset_config.get_bool('only valid', True)

--- a/packages/grid_control_cms/provider_cms.py
+++ b/packages/grid_control_cms/provider_cms.py
@@ -43,7 +43,7 @@ class CMSBaseProvider(DataProvider):
 			['lumi metadata', '%s lumi metadata' % datasource_name], default=not self._lumi_filter.empty())
 		config.set('phedex sites matcher mode', 'ShellStyleMatcher', '?=')
 		# PhEDex blacklist: 'T1_*_Disk nodes allow user jobs - other T1's dont!
-		self._phedex_filter = dataset_config.get_filter('phedex sites', '-* T1_*_Disk T2_* T3_*',
+		self._phedex_filter = dataset_config.get_filter('phedex sites', '-* T1_DE_KIT T1_*_Disk T2_* T3_*',
 			default_matcher='BlackWhiteMatcher', default_filter='StrictListFilter')
 		self._only_complete = dataset_config.get_bool('only complete sites', True)
 		self._only_valid = dataset_config.get_bool('only valid', True)


### PR DESCRIPTION
At T1_DE_KIT, the user spaces can also be located at T1_DE_KIT, and not only at _Disk as for other T1's. We have published datasets to be used by TauPOG / H->tautau analysts at our user space at T1_DE_KIT and with this fix these can be accessed using GC.