### PR TITLE
Python 3.7 compatibility

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6"]
+        python-version: ["3.6", "3.7"]
 
     steps:
     - uses: actions/checkout@v4

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - 2.7
   - 3.6
+  - 3.7
 env:
   - GC_WRAPPER='coverage run -a'
 matrix:

--- a/packages/grid_control/backends/condor_wms/condor_wms.py
+++ b/packages/grid_control/backends/condor_wms/condor_wms.py
@@ -311,7 +311,7 @@ class Condor(BasicWMS):
 	def _get_jobs_output(self, gc_id_jobnum_list):
 		# retrieve task output files from sandbox directory
 		if not len(gc_id_jobnum_list):
-			raise StopIteration
+			return
 
 		activity = Activity('retrieving job outputs')
 		for gc_id, jobnum in gc_id_jobnum_list:

--- a/packages/grid_control/backends/htcondor_wms/htcondor_wms.py
+++ b/packages/grid_control/backends/htcondor_wms/htcondor_wms.py
@@ -191,7 +191,7 @@ class HTCondor(BasicWMS):
 
 	def check_jobs(self, gc_id_jobnum_list):
 		if not len(gc_id_jobnum_list):
-			raise StopIteration
+			return
 		activity   = Activity('Checking jobs')
 		assert not bool(lfilter( lambda htcid: htcid.scheddURI != self._schedd.getURI(), self._splitGcRequests(gc_id_jobnum_list))), 'Bug! Got jobs at Schedds %s, but servicing only Schedd %s' % (lfilter( lambda itr: itr.scheddURI != self._schedd.getURI(), self._splitGcRequests(gc_id_jobnum_list)), self._schedd.getURI())
 		rawJobInfoMaps = self._schedd.check_jobs(
@@ -211,7 +211,7 @@ class HTCondor(BasicWMS):
 
 	def _get_jobs_output(self, gc_id_jobnum_list):
 		if not len(gc_id_jobnum_list):
-			raise StopIteration
+			return
 		activity   = Activity('Fetching jobs')
 		assert not bool(lfilter( lambda htcid: htcid.scheddURI != self._schedd.getURI(), self._splitGcRequests(gc_id_jobnum_list))), 'Bug! Got jobs at Schedds %s, but servicing only Schedd %s' % (lfilter( lambda itr: itr.scheddURI != self._schedd.getURI(), self._splitGcRequests(gc_id_jobnum_list)), self._schedd.getURI())
 		returnedJobs = self._schedd.getJobsOutput(
@@ -227,7 +227,7 @@ class HTCondor(BasicWMS):
 	
 	def cancel_jobs(self, gc_id_jobnum_list):
 		if not len(gc_id_jobnum_list):
-			raise StopIteration
+			return
 		activity   = Activity('Canceling jobs')
 		assert not bool(lfilter( lambda htcid: htcid.scheddURI != self._schedd.getURI(), self._splitGcRequests(gc_id_jobnum_list))), 'Bug! Got jobs at Schedds %s, but servicing only Schedd %s' % (lfilter( lambda itr: itr.scheddURI != self._schedd.getURI(), self._splitGcRequests(gc_id_jobnum_list)), self._schedd.getURI())
 		canceledJobs = self._schedd.cancel_jobs(

--- a/packages/grid_control/backends/wms_cream.py
+++ b/packages/grid_control/backends/wms_cream.py
@@ -114,7 +114,7 @@ class CreamWMS(GridWMS):
 		if exit_code != 0:
 			if 'Keyboard interrupt raised by user' in proc.stdout.read_log():
 				remove_files([log, tmp_dn])
-				raise StopIteration
+				return
 			else:
 				self._log.log_process(proc)
 			self._log.error('Trying to recover from error ...')
@@ -154,7 +154,7 @@ class CreamWMS(GridWMS):
 	def _get_jobs_output(self, gc_id_jobnum_list):
 		# Get output of jobs and yield output dirs
 		if len(gc_id_jobnum_list) == 0:
-			raise StopIteration
+			return
 
 		tmp_dn = os.path.join(self._path_output, 'tmp')
 		try:

--- a/packages/grid_control/backends/wms_grid.py
+++ b/packages/grid_control/backends/wms_grid.py
@@ -69,7 +69,7 @@ class GridWMS(BasicWMS):
 	def _get_jobs_output(self, gc_id_jobnum_list):
 		# Get output of jobs and yield output dirs
 		if len(gc_id_jobnum_list) == 0:
-			raise StopIteration
+			return
 
 		root_dn = os.path.join(self._path_output, 'tmp')
 		try:
@@ -107,7 +107,7 @@ class GridWMS(BasicWMS):
 		if exit_code != 0:
 			if 'Keyboard interrupt raised by user' in proc.stderr.read(timeout=0):
 				remove_files([jobs, root_dn])
-				raise StopIteration
+				return
 			else:
 				self._log.log_process(proc, files={'jobs': SafeFile(jobs).read()})
 			self._log.error('Trying to recover from error ...')

--- a/packages/grid_control/backends/wms_jms.py
+++ b/packages/grid_control/backends/wms_jms.py
@@ -36,8 +36,11 @@ class JMSCheckJobs(CheckJobsWithProcess):
 		tmp_head = [CheckInfo.WMSID, 'user', 'group', 'job_name', CheckInfo.QUEUE, 'partition',
 			'nodes', 'cpu_time', 'wall_time', 'memory', 'queue_time', CheckInfo.RAW_STATUS]
 		status_iter = ifilter(identity, proc.stdout.iter(self._timeout))
-		next(status_iter)
-		next(status_iter)
+		try:
+			next(status_iter)
+			next(status_iter)
+		except StopIteration:
+			return
 		for line in status_iter:
 			tmp = lmap(lambda x: x.strip(), line.replace('\x1b(B', '').replace('\x1b[m', '').split())
 			job_info = dict(izip(tmp_head, tmp[:12]))

--- a/packages/grid_control/backends/wms_local.py
+++ b/packages/grid_control/backends/wms_local.py
@@ -97,7 +97,7 @@ class LocalWMS(BasicWMS):
 
 	def _get_jobs_output(self, gc_id_jobnum_list):
 		if not len(gc_id_jobnum_list):
-			raise StopIteration
+			return
 
 		activity = Activity('retrieving %d job outputs' % len(gc_id_jobnum_list))
 		for gc_id, jobnum in gc_id_jobnum_list:

--- a/packages/grid_control/backends/wms_lsf.py
+++ b/packages/grid_control/backends/wms_lsf.py
@@ -42,7 +42,10 @@ class LSFCheckJobs(CheckJobsWithProcess):
 
 	def _parse(self, proc):
 		status_iter = proc.stdout.iter(timeout=self._timeout)
-		next(status_iter)
+		try:
+			next(status_iter)
+		except StopIteration:
+			return
 		tmp_head = [CheckInfo.WMSID, 'user', CheckInfo.RAW_STATUS,
 			CheckInfo.QUEUE, 'from', CheckInfo.WN, 'job_name']
 		for line in ifilter(identity, status_iter):

--- a/packages/grid_control/parameters/psource_basic.py
+++ b/packages/grid_control/parameters/psource_basic.py
@@ -197,6 +197,10 @@ class RNGParameterSource(SingleParameterSource):
 class RegexTransformParameterSource(SingleParameterSource):
 	alias_list = ['regex_transform']
 
+	# https://stackoverflow.com/questions/61249613/python-re-sub-behavior-changed-with-3-7-bug-or-not
+	# Change in python 3.7 re.sub (https://docs.python.org/3/library/re.html#re.sub):
+	# Empty matches for the pattern are replaced when adjacent to a previous non-empty match.
+	# Rationale: https://bugs.python.org/issue32308
 	def __init__(self, output_vn, source_vn, regex_dict, regex_order, default=None):
 		SingleParameterSource.__init__(self, '!%s' % output_vn,
 			[output_vn, source_vn, regex_order, str_dict_linear(regex_dict)])

--- a/packages/python_compat_json.py
+++ b/packages/python_compat_json.py
@@ -28,7 +28,7 @@ def py_make_scanner(context):
         try:
             nextchar = string[idx]
         except IndexError:
-            raise StopIteration
+            raise
 
         if nextchar == '"':
             return parse_string(string, idx + 1, encoding, strict)
@@ -59,7 +59,7 @@ def py_make_scanner(context):
         elif nextchar == '-' and string[idx:idx + 9] == '-Infinity':
             return parse_constant('-Infinity'), idx + 9
         else:
-            raise StopIteration
+            return
 
     return _scan_once
 
@@ -311,7 +311,7 @@ def JSONArray(s_and_end, scan_once, _w=WHITESPACE.match, _ws=WHITESPACE_STR):
     while True:
         try:
             value, end = scan_once(s, end)
-        except StopIteration:
+        except IndexError:
             raise ValueError(errmsg("Expecting object", s, end))
         _append(value)
         nextchar = s[end:end + 1]
@@ -442,7 +442,7 @@ class JSONDecoder(object):
         """
         try:
             obj, end = self.scan_once(s, idx)
-        except StopIteration:
+        except IndexError:
             raise ValueError("No JSON object could be decoded")
         return obj, end
 

--- a/packages/python_compat_tarfile.py
+++ b/packages/python_compat_tarfile.py
@@ -2486,12 +2486,12 @@ class TarIter:
             tarinfo = self.tarfile.next()
             if not tarinfo:
                 self.tarfile._loaded = True
-                raise StopIteration
+                return
         else:
             try:
                 tarinfo = self.tarfile.members[self.index]
             except IndexError:
-                raise StopIteration
+                return
         self.index += 1
         return tarinfo
 


### PR DESCRIPTION
## Necessary changes
The basic "breaking" change was [PEP 479 -- Change StopIteration handling inside generators](https://www.python.org/dev/peps/pep-0479).

There is a [breaking change](https://docs.python.org/3/library/re.html#re.sub) in `re.sub`:
> Empty matches for the pattern are replaced when adjacent to a previous non-empty match.

I chose to live with this change and adapted the tests, because implementing a different behaviour wrt. to the python stdlib would certainly lead to more confusion. I don't expect many users to use this, but some configs might need a change.

## Test coverage
Before/while preparing this, I had to revive the CI (#84 #87). Unfortunately I did not manage to get all tests running easily. The only tests missing now are [CMS-related](https://github.com/grid-control/testsuite/blob/f9642e9b183717cf2dc590afd88670c3e4d579e3/test_gh_actions_testsuite.sh#L36-L38). So it could be that there is something still missing for python 3.7 in those code parts. I manually tested some CMS-specific configs, but not extensively.

I am not sure how fast (or if) I can get the remaining tests running, so I decided to leave it like this for now to continue moving towards python 3.9 (#86).

Closes #68