### PR TITLE
Python 3.8 compatibility

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7"]
+        python-version: ["3.6", "3.7", "3.8"]
 
     steps:
     - uses: actions/checkout@v4

--- a/packages/grid_control/backends/wms_gridengine.py
+++ b/packages/grid_control/backends/wms_gridengine.py
@@ -108,7 +108,7 @@ class GridEngineCheckJobs(CheckJobsWithProcess):
 						continue
 					if node.hasChildNodes():
 						job_info[str(node.nodeName)] = str(node.childNodes[0].nodeValue)
-				for job_info_key in job_info:
+				for job_info_key in list(job_info.keys()):
 					if str(job_info_key).lower() in self._job_status_key:
 						job_info[CheckInfo.WMSID] = job_info.pop(job_info_key)
 				job_info[CheckInfo.RAW_STATUS] = job_info.pop('state')

--- a/packages/grid_control/config/cinterface_typed.py
+++ b/packages/grid_control/config/cinterface_typed.py
@@ -38,7 +38,18 @@ class TypedConfigInterface(ConfigInterface):
 			if result is None:
 				raise ConfigError('Valid boolean expressions are: "true", "false"')
 			return result
-		return self._get_internal('bool', bool.__str__, _str2obj, None, option, default, **kwargs)
+
+		# Change in python 3.8, causing "TypeError" not to be thrown:
+		# https://docs.python.org/3/whatsnew/3.8.html
+		# "Removed __str__ implementations from builtin types bool, int, float, complex"
+		_obj2str = bool.__str__
+		if bool.__str__ == object.__str__:
+			def _obj2str(self):
+				if self == None:
+					raise TypeError("descriptor '__str__' requires a 'int' object but received a 'NoneType'")
+				return self.__str__()
+
+		return self._get_internal('bool', _obj2str, _str2obj, None, option, default, **kwargs)
 
 	def get_composited_plugin(self, option, default=unspecified, default_compositor=unspecified,
 			option_compositor=None, cls=Plugin, require_plugin=True,
@@ -76,7 +87,18 @@ class TypedConfigInterface(ConfigInterface):
 
 	def get_int(self, option, default=unspecified, **kwargs):
 		# Getting integer config options - using strict integer (de-)serialization
-		return self._get_internal('int', int.__str__, int, None, option, default, **kwargs)
+
+		# Change in python 3.8, causing "TypeError" not to be thrown:
+		# https://docs.python.org/3/whatsnew/3.8.html
+		# "Removed __str__ implementations from builtin types bool, int, float, complex"
+		_obj2str = int.__str__
+		if int.__str__ == object.__str__:
+			def _obj2str(self):
+				if self == None:
+					raise TypeError("descriptor '__str__' requires a 'int' object but received a 'NoneType'")
+				return self.__str__()
+
+		return self._get_internal('int', _obj2str, int, None, option, default, **kwargs)
 
 	def get_list(self, option, default=unspecified, parse_item=identity, **kwargs):
 		# Get whitespace separated list (space, tab, newline)


### PR DESCRIPTION
The main problem in python 3.8 was a bit tricky to find:

## Change in python 3.8, causing "TypeError" not to be thrown:
https://docs.python.org/3/whatsnew/3.8.html
"Removed `__str__` implementations from builtin types bool, int, float, complex"

See also https://github.com/python/cpython/issues/80974
https://github.com/python/cpython/issues/80974

## Changes in testsuite
One Exception changed from OSError to BadGzipFile: grid-control/testsuite@ea20e84ae202379933b0a8d061af575dcf46b6a7

## Test coverage
The same caveats remain as for #88

Closes  #85