### PR TITLE
Add `_at_fork_reinit` to `GCLock` API.

### DIFF
--- a/packages/grid_control/utils/thread_tools.py
+++ b/packages/grid_control/utils/thread_tools.py
@@ -136,6 +136,12 @@ class GCLock(object):
 	def __init__(self, lock=None):
 		self._lock = lock or threading.Lock()
 
+	def _at_fork_reinit(self):
+		try:
+			self._lock._at_fork_reinit()
+		except AttributeError:
+			pass
+
 	def acquire(self, timeout=None):
 		try:
 			if timeout == 0:  # Non-blocking


### PR DESCRIPTION
This PR implements a trivial `_at_fork_reinit` method for `GCLock`, which is required as part of the API of objects used as `threading` locks since Python `3.9.0`. More information at https://github.com/python/cpython/issues/84270.

If this method is not present, GC catches and ignores the `AttributeError` but issues a verbose warning cluttering the UI:

```
Exception ignored in: <function _after_at_fork_child_reinit_locks at 0x0>
Traceback (most recent call last):
  File "/lib/python3.9/logging/__init__.py", line 255, in _after_at_fork_child_reinit_locks
    handler._at_fork_reinit()
  File "/lib/python3.9/logging/__init__.py", line 894, in _at_fork_reinit
    self.lock._at_fork_reinit()
AttributeError: 'GCLock' object has no attribute '_at_fork_reinit'
```

