### PR TITLE
Implement handling of `davs://` URLs in SE operations.

### DIFF
--- a/docs/examples/Example06_storage.conf
+++ b/docs/examples/Example06_storage.conf
@@ -2,14 +2,17 @@
 
 [global]
 include         = Example05_dataset.conf    ; Settings based on dataset example
-backend         = grid                      ; Use grid submission 
+backend         = local                     ; Use local submission 
+
+[backend]
+proxy = VomsProxy
 
 [UserTask]
 input files     = Example06_storage.conf    ; Send file "Example06_storage.conf" together with the job
 output files    = output.vars1              ; Return file "output.vars1" to the job output directory
 
 [storage]
-se path         = srm://dcache-se-cms.desy.de:8443/srm/managerv2?SFN=/pnfs/desy.de/cms/tier2/store/user/stober
+se path         = davs://dcache-cms-webdav.desy.de:2880/pnfs/desy.de/cms/tier2/store/user/stober
                                             ; path is taken from "scripts/debugToolCMS.py -s T2_DE_DESY"
 se output files = output.vars2 output.vars3 ; Store file "output.vars2" on the SE
 se output pattern = JOB_OUTPUT_@GC_JOBID@_@X@

--- a/packages/grid_control/share/gc-run.lib
+++ b/packages/grid_control/share/gc-run.lib
@@ -428,9 +428,10 @@ url_ls() {
 			done
 			;;
 		"davs://"*)
-			LSCMD="`getcommand davix-ls`"
+			LSCMD="`getcommand davix-ls gfal-ls`"
 			gc_check_bin "$LSCMD" 1>&2
-			eval "$LSCMD -P grid $1"
+			[ "$(basename $LSCMD)" == "davix-ls" ] && LSCMD="$LSCMD -P grid"
+			eval "$LSCMD $1"
 			;;
 		"file://"*)
 			cd "${1#file://}" && ls -1d ${2:-*} && cd "$OLDPWD";;
@@ -455,8 +456,9 @@ url_exists() {
 		"file://"*)
 			print_and_eval " " "test" "-s ${1#file://}";;
 		"davs://"*)
-			EXCMD="`getcommand davix-ls`"
-			print_and_eval "$EXCMD" "-P grid" "$1";;
+			EXCMD="`getcommand davix-ls gfal-ls`"
+			[ "$(basename $EXCMD)" == "davix-ls" ] && EXCMD="$EXCMD -P grid"
+			print_and_eval "$EXCMD" "$1";;
 		*)
 			echo "Unsupported URL: $1" >&2 && fail 106;;
 	esac

--- a/packages/grid_control/share/gc-run.lib
+++ b/packages/grid_control/share/gc-run.lib
@@ -618,6 +618,7 @@ url_copy_single() {
 					CPCMD="`getcommand davix-put gfal-copy`"
 					[ "$(basename $CPCMD)" == "davix-put" ] && SRC_URL="${1#file://}" || SRC_URL="$1"
 					[ "$(basename $CPCMD)" == "davix-put" ] && CPOPTS="-P grid" || CPOPTS=""
+					[ "$(basename $CPCMD)" == "gfal-copy" ] && CPOPTS="--force"
 					print_and_eval "$CPCMD" "$CPOPTS" "$SRC_URL $2";;
 				"file://"*)
 					print_and_eval "url_copy_single_local" "$1 $2";;

--- a/packages/grid_control/share/gc-run.lib
+++ b/packages/grid_control/share/gc-run.lib
@@ -602,7 +602,9 @@ url_copy_single() {
 					[ "$(basename $CPCMD)" == "davix-get" ] && CPOPTS="-P grid" || CPOPTS=""
 					print_and_eval "$CPCMD" "$CPOPTS" "$1 $DST_URL";;
 				"davs://"*)
-					print_and_eval "`getcommand davix-cp gfal-copy`" "-P grid" "$1 $2";;
+					CPCMD="`getcommand davix-cp gfal-copy`"
+					[ "$(basename $CPCMD)" == "davix-get" ] && CPOPTS="-P grid" || CPOPTS=""
+					print_and_eval "$CPCMD" "$CPOPTS" "$1 $2";;
 				*)
 					echo "Unsupported copy from $1 to $2" >&2 && fail 106;;
 			esac;;

--- a/packages/grid_control/share/gc-run.lib
+++ b/packages/grid_control/share/gc-run.lib
@@ -427,6 +427,11 @@ url_ls() {
 				esac
 			done
 			;;
+		"davs://"*)
+			LSCMD="`getcommand davix-ls`"
+			gc_check_bin "$LSCMD" 1>&2
+			eval "$LSCMD -P grid $1"
+			;;
 		"file://"*)
 			cd "${1#file://}" && ls -1d ${2:-*} && cd "$OLDPWD";;
 		*)	echo "Unsupported URL: $1" >&2 && fail 106;;
@@ -449,6 +454,9 @@ url_exists() {
 			print_and_eval "$EXCMD" "$1";;
 		"file://"*)
 			print_and_eval " " "test" "-s ${1#file://}";;
+		"davs://"*)
+			EXCMD="`getcommand davix-ls`"
+			print_and_eval "$EXCMD" "-P grid" "$1";;
 		*)
 			echo "Unsupported URL: $1" >&2 && fail 106;;
 	esac
@@ -472,6 +480,9 @@ url_rm() {
 				print_and_eval "$RM_CMD" "${RM_OPTS}" "$FILE";;
 			"file://"*)
 				print_and_eval " " "rm" "${FILE#file://}";;
+			"davs://"*)
+				RM_CMD="`getcommand davix-rm`"
+				print_and_eval "$RM_CMD" "-P grid" "$FILE";;
 			*)
 				echo "Unsupported URL: $FILE" >&2 && fail 106;;
 		esac
@@ -490,6 +501,8 @@ url_mkdir() {
 				print_and_eval "`getcommand edg-gridftp-mkdir`" "$FILE";;
 			"file://"*)
 				print_and_eval " " "mkdir" "-p" "${FILE#file://}";;
+			"davs://"*)
+				print_and_eval "`getcommand davix-mkdir`" "-P grid" "$FILE";;
 			*)
 				echo "Unsupported URL: $FILE" >&2 && fail 106;;
 		esac
@@ -578,6 +591,19 @@ url_copy_single() {
 					print_and_eval "url_copy_connector" "$1" "$2";;
 			esac;;
 
+		"davs://"*)
+			case "$2" in
+				"file://"*)
+					CPCMD="`getcommand davix-get gfal-copy`"
+					[ "$(basename $CPCMD)" == "davix-get" ] && DST_URL="${2#file://}" || DST_URL="$2"
+					[ "$(basename $CPCMD)" == "davix-get" ] && CPOPTS="-P grid" || CPOPTS=""
+					print_and_eval "$CPCMD" "$CPOPTS" "$1 $DST_URL";;
+				"davs://"*)
+					print_and_eval "`getcommand davix-cp gfal-copy`" "-P grid" "$1 $2";;
+				*)
+					echo "Unsupported copy from $1 to $2" >&2 && fail 106;;
+			esac;;
+
 		"file://"*)
 			case "$2" in
 				"rfio://"*)
@@ -586,6 +612,11 @@ url_copy_single() {
 					print_and_eval "`getcommand globus-url-copy`" "$1 $2";;
 				"srm://"*)
 					print_and_eval "url_copy_single_srm" "$1 $2";;
+				"davs://"*)
+					CPCMD="`getcommand davix-put gfal-copy`"
+					[ "$(basename $CPCMD)" == "davix-put" ] && SRC_URL="${1#file://}" || SRC_URL="$1"
+					[ "$(basename $CPCMD)" == "davix-put" ] && CPOPTS="-P grid" || CPOPTS=""
+					print_and_eval "$CPCMD" "$CPOPTS" "$SRC_URL $2";;
 				"file://"*)
 					print_and_eval "url_copy_single_local" "$1 $2";;
 				*)
@@ -613,7 +644,7 @@ url_copy() {
 	SOURCE_FILES=""
 	SOURCE_URL="$1"
 	case "$SOURCE_URL" in
-		"rfio://"* | "gsiftp://"* | "srm://"* | "dir://"*)
+		"rfio://"* | "gsiftp://"* | "srm://"* | "dir://"* | "davs://"*)
 			# copy from SE
 			SOURCE_URL="`echo "$SOURCE_URL" | sed -e 's@dir://@file://@'`"
 			if [[ "$FILENAMES" == *\** ]]; then
@@ -647,7 +678,7 @@ url_copy() {
 
 	TARGET_URL="$2"
 	case "$TARGET_URL" in
-		"rfio://"* | "gsiftp://"* | "srm://"* | "dir://"*)
+		"rfio://"* | "gsiftp://"* | "srm://"* | "dir://"* | "davs://"*)
 			# copy to SE
 			TARGET_PATTERN="${SE_OUTPUT_PATTERN:-@X@}"
 			TARGET_URL="`echo "$TARGET_URL" | sed -e 's@dir://@file://@'`"

--- a/packages/grid_control/share/gc-run.lib
+++ b/packages/grid_control/share/gc-run.lib
@@ -483,8 +483,9 @@ url_rm() {
 			"file://"*)
 				print_and_eval " " "rm" "${FILE#file://}";;
 			"davs://"*)
-				RM_CMD="`getcommand davix-rm`"
-				print_and_eval "$RM_CMD" "-P grid" "$FILE";;
+				RM_CMD="`getcommand davix-rm gfal-rm`"
+				[ "$(basename $RM_CMD)" == "davix-rm" ] && RM_OPTS="-P grid" || RM_OPTS=""
+				print_and_eval "$RM_CMD" "$RM_OPTS" "$FILE";;
 			*)
 				echo "Unsupported URL: $FILE" >&2 && fail 106;;
 		esac

--- a/packages/grid_control/share/gc-storage-tool
+++ b/packages/grid_control/share/gc-storage-tool
@@ -509,6 +509,15 @@ sc_copy()
 				*)
 					sc_copy_connector "$1" "$2";;
 			esac;;
+		"davs://"*)
+			case "$2" in
+				"file://"*)
+					sc_try_copy sc_call "gfal-copy" "$GFAL_COPY_ARGS" "$1" "$2" || \
+					sc_try_copy sc_call "davix-get" -P grid "$1" "${2#file://}" || \
+					sc_fail "webdav_local_copy_failed";;
+				*)
+					sc_copy_connector "$1" "$2";;
+			esac;;
 		"file://"*)
 			if test ! -f "${1#file://}"; then
 				sc_fail "source_file_missing"
@@ -572,6 +581,10 @@ sc_copy()
 					sc_try_copy sc_call "srmcp" -2 -debug=true -streams_num=1 "$1" "$2" || \
 					sc_try_copy sc_call "arccp" "$1" "$2" || \
 					sc_fail "local_srm_copy_failed";;
+				"davs://"*)
+					sc_try_copy sc_call "gfal-copy" "$GFAL_COPY_ARGS" "$1" "$2" || \
+					sc_try_copy sc_call "davix-put" -P grid "${1#file://}" "$2" || \
+					sc_fail "local_webdav_copy_failed";;
 				"file://"*)
 					sc_try_copy sc_call "cp" "${1#file://}" "${2#file://}" || \
 					sc_fail "local_local_copy_failed";;


### PR DESCRIPTION
This PR updates the tools for interacting with SEs in `gc-run.lib` and `gc_storage_tool` to support handling WebDAV grid URLs starting with `davs://`.

Operations like `ls`, `exists` and `mkdir` are implemented for `davs://` URLs are implemented via the `davix-ls`, `davix-mkdir` utilities.

Copy operations to and from local `file://` to `davs://` are implemented via `davix-get` and `davix-put`, with a fallback to `gfal-copy`. Similarly, WebDAV-to-WebDAV copy is implemented via `davix-cp`.
