### PR TITLE
Python 3.9 compatibility

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8"]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
 
     steps:
     - uses: actions/checkout@v4

--- a/packages/grid_control/utils/thread_tools.py
+++ b/packages/grid_control/utils/thread_tools.py
@@ -137,10 +137,8 @@ class GCLock(object):
 		self._lock = lock or threading.Lock()
 
 	def _at_fork_reinit(self):
-		try:
-			self._lock._at_fork_reinit()
-		except AttributeError:
-			pass
+		# new in python 3.9: https://bugs.python.org/issue40089
+		self._lock._at_fork_reinit()
 
 	def acquire(self, timeout=None):
 		try:


### PR DESCRIPTION
This was easier than 3.7 and 3.8

## use new _at_fork_reinit() for lock
introduced in python 3.9: https://bugs.python.org/issue40089
and required (e.g. by the logging library)

## Grid UI for EL9
`/cvmfs/grid.cern.ch/alma9-ui-test/etc/profile.d/setup-alma9-test.sh`
for now and officially not in "production", yet, but the best we have for now.

## Test coverage
The same caveats remain as for #88

Closes #86